### PR TITLE
Align fonts to Lingua Libre's graphic charter

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -37,8 +37,8 @@
     --top-z-index: 2;
     --middle-z-index: 1;
     --bottom-z-index: 0;
-    --base-font-family: "Open Sans", sans-serif;
-    --strong-font-family: "Zilla Slab", "Georgia", "Utopia", "Charter", serif;
+    --base-font-family: "Lato", sans-serif;
+    --strong-font-family: "Charter", "Lato", serif;
     --font-size-xs: 12px;
     --font-size-sm: 14px;
     --font-size: 16px;

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>Lingualibre Languages Gallery</title>
   <link id="style-fonts" rel="stylesheet" href="css/fonts.css">
   <link id="style-main" rel="stylesheet" href="css/style.css">
+  <link rel="shortcut icon" href="https://lingualibre.org/resources/assets/logo/lingualibre-favicon.ico">
 </head>
 <body>
 


### PR DESCRIPTION
Hey there! Just a light PR about the default fonts of the page.

Up until now, the font style matches CommonVoice's graphic charter rather than Lingua Libre's.

BTW, I think LanguagesGallery should be moved under the lingualibre organization rather than a personal user space.